### PR TITLE
Adds docker private repo auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target/
 work*/
+.idea

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ nomadJobTemplate(
             envVar(key: 'my-super-var', value: '1234'),
             envVar(key: 'OTHER_VAR', value: 'foobar'),
         ],
+        auth: auth(username: 'bob', password: '1234', serverAddress: 'my-private-repo:15432')
     )
   ]
 ) {
@@ -213,6 +214,11 @@ This specifies the values for the Nomad job that will be executed:
   java -jar /local/slave.jar -jnlpUrl $JENKINS_JNLP_URL -secret $JENKINS_SECRET'
   ```
 
+* `auth`: Provide [authentication](https://www.nomadproject.io/docs/drivers/docker/#auth)
+for a private docker repository.
+
+  auth undergoes the same variable names expansion as in the
+  case of the `image` setting.
 
 
 ## Migrating from [Nomad Plugin](https://wiki.jenkins.io/display/JENKINS/Nomad+Plugin)

--- a/src/main/java/info/multani/jenkins/plugins/nomad/model/Auth.java
+++ b/src/main/java/info/multani/jenkins/plugins/nomad/model/Auth.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package info.multani.jenkins.plugins.nomad.model;
+
+import hudson.Extension;
+import hudson.ExtensionPoint;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import java.io.Serializable;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class Auth extends AbstractDescribableImpl<Auth>
+        implements Serializable, ExtensionPoint {
+
+    private static final long serialVersionUID = 5332584988703580876L;
+
+    private String username;
+    private String password;
+    private String serverAddress;
+
+    @DataBoundConstructor
+    public Auth(String username, String password, String serverAddress) {
+        this.username = username;
+        this.password = password;
+        this.serverAddress = serverAddress;
+    }
+
+    public String getUsername() {
+        return (username == null) ? "" : username;
+    }
+
+    public void setUsername(String value) {
+        this.username = value;
+    }
+
+    public String getPassword() {
+        return (password == null) ? "" : password;
+    }
+
+    public void setPassword(String value) {
+        this.password = value;
+    }
+
+    public String getServerAddress() {
+        return (serverAddress == null) ? "" : serverAddress;
+    }
+
+    public void setServerAddress(String value) {
+        this.serverAddress = value;
+    }
+    @Override
+    public String toString() {
+        return "Auth[username=" + getUsername() + ", password=" + getPassword() + ", serverAddress" + getServerAddress()  + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((username == null) ? 0 : username.hashCode());
+        result = prime * result + ((password == null) ? 0 : password.hashCode());
+        result = prime * result + ((serverAddress == null) ? 0 : serverAddress.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof Auth)) {
+            return false;
+        }
+
+        Auth other = (Auth) obj;
+
+        if (username == null) {
+            if (other.username != null) {
+                return false;
+            }
+        } else if (!username.equals(other.username)) {
+            return false;
+        }
+
+        if (password == null) {
+            if (other.password != null) {
+                return false;
+            }
+        } else if (!password.equals(other.password)) {
+            return false;
+        }
+
+        if (serverAddress == null) {
+            if (other.serverAddress != null) {
+                return false;
+            }
+        } else if (!serverAddress.equals(other.serverAddress)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Extension
+    @Symbol("auth")
+    public static class DescriptorImpl extends Descriptor<Auth> {
+
+        @Override
+        public String getDisplayName() {
+            return "Auth";
+        }
+    }
+}


### PR DESCRIPTION
I needed a way to access a private docker repo (we use Sonatype Nexus).

This PR adds an Auth class for capturing username, password, and server_address.

The Auth class get's added into the TaskTemplate in the config block. Doc here: https://www.nomadproject.io/docs/drivers/docker/#authentication

Also updated the README to show how to add auth to a template from the Jenkinsfile.

How I tested:
- images that don't specify an auth stanza still work!
- images that specify all three auth args work (pulled from a private docker repo hosted on a Nexus3 server)
- should have no trouble logging into a private repo in docker hub (can just leave out the server_address or define it as an empty string, "")
My working Jenkinsfile includes this stanza:
```
taskGroups: [
  taskTemplate(
    name: 'jnlp',
    image: "$docker_repo_addr/go-node-build-agent:latest",
    auth: auth(username: "$Username", password: "$Password", serverAddress: docker_repo_addr),
    resourcesMemory: 2048,
    resourcesCPU: 1000,
  )
]
```
A `withCredentials` is wrapped around that to drop in the $Username and $Password

Apologies if the Java is a little rough - it's been a minute or two since I have used the language and the tools.

And thanks for the great plugin!